### PR TITLE
Support pep8/pylint

### DIFF
--- a/.lint.config.json
+++ b/.lint.config.json
@@ -1,0 +1,9 @@
+{
+	"lint": {
+		"python": {
+			"whitelist": [
+				".*\\.py$"
+			]
+		}
+	}
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: python
 
 python:
-  - "3.2"
+  - "3.3"
   - "3.5"
 
 sudo: false
 
-addons:
-  apt:
-    packages:
-      - pep8
+install:
+  - pip install pylint
+  - pip install pep8
 
 script:
   - python3 linters_test.py
-  - pep8 *.py test/*.py
+  - python3 lint.py validate --all

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ linters soportados (con sus respectivas opciones) son:
     sección `<script>..</script>` del template.
 * `php`: Corre PHP Code Beautifier.
   * `standard`: Una cadena con la ruta del estándar de phpcbf.
+* `python`: Corre pep8 y pylint.
+  * `pep8_config`: Una cadena con la ruta del archivo de configuración para
+     pep8.
+  * `pylint_config`: Una cadena con la ruta del archivo de configuración para
+     pylint.
 * `custom`: Corre comandos personalizados.
   * `commands`: Un arreglo con comandos.
 

--- a/git_tools.py
+++ b/git_tools.py
@@ -35,11 +35,15 @@ class COLORS:
 
 class Argument:
     '''Class that represents a single argument for argparse.ArgumentParser.'''
+    # pylint: disable=R0903
+
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
 
     def add_to(self, parser):
+        '''Adds an additional argument to the parser.'''
+
         parser.add_argument(*self.args, **self.kwargs)
 
 
@@ -165,11 +169,13 @@ def prompt(question, default=True):
 
         response = response.strip().lower()
         if not response:
-            return default
+            break
         if yes_str.startswith(response):
             return True
         if no_str.startswith(response):
             return False
+
+    return default
 
 
 def file_contents(args, root, filename):

--- a/linters.py
+++ b/linters.py
@@ -46,14 +46,20 @@ _JAVASCRIPT_TOOLCHAIN_VERIFIED = False
 class LinterException(Exception):
     '''A fatal exception during linting.'''
 
-    def __init__(self, message):
+    def __init__(self, message, fixable=True):
         super().__init__(message)
         self.__message = message
+        self.__fixable = fixable
 
     @property
     def message(self):
         '''A message that can be presented to the user.'''
         return self.__message
+
+    @property
+    def fixable(self):
+        '''Whether this exception supports being fixed.'''
+        return self.__fixable
 
 
 def _custom_command(command, filename, original_filename):
@@ -138,7 +144,7 @@ class Linter(object):
     __metaclass__ = ABCMeta
 
     def __init__(self):
-        super().__init__()
+        pass
 
     @abstractmethod
     def run_one(self, filename, contents):
@@ -376,6 +382,50 @@ class PHPLinter(Linter):
         return 'php'
 
 
+class PythonLinter(Linter):
+    '''Runs pep8 and pylint.'''
+    # pylint: disable=R0903
+
+    def __init__(self, options=None):
+        super().__init__()
+        self.__options = options or {}
+
+    def run_one(self, filename, contents):
+        with tempfile.TemporaryDirectory(prefix='python_linter_') as tmpdir:
+            tmp_path = os.path.join(tmpdir, os.path.basename(filename))
+            with open(tmp_path, 'wb') as pyfile:
+                pyfile.write(contents)
+
+            python3 = _which('python3')
+
+            args = [python3, '-m', 'pep8', tmp_path]
+            try:
+                logging.debug('lint_python: Running %s', args)
+                subprocess.check_output(args, stderr=subprocess.STDOUT)
+            except subprocess.CalledProcessError as cpe:
+                raise LinterException(
+                    str(cpe.output, encoding='utf-8').replace(tmp_path,
+                                                              filename),
+                    fixable=False)
+
+            args = [python3, '-m', 'pylint', '--output-format=parseable',
+                    '--reports=no', tmp_path]
+            try:
+                logging.debug('lint_python: Running %s', args)
+                subprocess.check_output(args, stderr=subprocess.STDOUT)
+            except subprocess.CalledProcessError as cpe:
+                raise LinterException(
+                    str(cpe.output, encoding='utf-8').replace(tmp_path,
+                                                              filename),
+                    fixable=False)
+
+            return contents, []
+
+    @property
+    def name(self):
+        return 'python'
+
+
 class CustomLinter(Linter):
     '''Runs a custom command as linter.'''
     # pylint: disable=R0903
@@ -400,7 +450,8 @@ class CustomLinter(Linter):
                     logging.debug('lint_custom: Running %s', args)
                     subprocess.check_output(args, stderr=subprocess.STDOUT)
                 except subprocess.CalledProcessError as cpe:
-                    raise LinterException(str(cpe.output, encoding='utf-8'))
+                    raise LinterException(str(cpe.output, encoding='utf-8'),
+                                          fixable=False)
 
             with open(tmp.name, 'rb') as tmp_in:
                 return tmp_in.read(), ['custom']

--- a/linters_test.py
+++ b/linters_test.py
@@ -124,6 +124,15 @@ class TestLinters(unittest.TestCase):
             b'<?php\necho [\'foo\'];\n')
         self.assertEqual(violations, ['php'])
 
+    def test_python(self):
+        """Tests PythonLinter."""
+
+        linter = linters.PythonLinter()
+
+        with self.assertRaisesRegex(linters.LinterException, r'.*\bE111\b.*'):
+            linter.run_one(
+                'test.py', b'def main():\n  pass\n')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/uppercase_linter.py
+++ b/test/uppercase_linter.py
@@ -9,7 +9,7 @@ import sys
 def main():
     """Main entrypoint."""
 
-    filename, _ = sys.argv[1:]
+    filename = sys.argv[1]
 
     with open(filename, 'r') as input_file:
         contents = input_file.read()


### PR DESCRIPTION
This change adds support for pep8/pylint. It also introduces the concept
of non-fixable linter exceptions, since pep8/pylint don't really lend
themselves to autofixes.