### PR TITLE
Agregando linter para evitar que los archivos .vue contengan id's

### DIFF
--- a/lint.py
+++ b/lint.py
@@ -21,6 +21,7 @@ _LINTER_MAPPING = {
     'javascript': linters.JavaScriptLinter,
     'html': linters.HTMLLinter,
     'vue': linters.VueLinter,
+    'vueid': linters.VueIdLinter,
     'php': linters.PHPLinter,
     'python': linters.PythonLinter,
 }

--- a/lint.py
+++ b/lint.py
@@ -21,7 +21,6 @@ _LINTER_MAPPING = {
     'javascript': linters.JavaScriptLinter,
     'html': linters.HTMLLinter,
     'vue': linters.VueLinter,
-    'vueid': linters.VueIdLinter,
     'php': linters.PHPLinter,
     'python': linters.PythonLinter,
 }

--- a/linters.py
+++ b/linters.py
@@ -260,7 +260,7 @@ class VueHTMLParser(HTMLParser):
         self._stack.append((tag, self.get_starttag_text(), (line - 1, col)))
         if not self._id_linter_enabled:
             return
-        for name, value in attrs:
+        for name, _ in attrs:
             if name == 'id':
                 raise LinterException(
                     'Use of "id" attribute in .vue files is ' +

--- a/linters.py
+++ b/linters.py
@@ -260,12 +260,11 @@ class VueHTMLParser(HTMLParser):
         self._stack.append((tag, self.get_starttag_text(), (line - 1, col)))
         for attributes in attrs:
             for attr in attributes:
-                if attr == 'id' and self._id_linter_enabled == True:
+                if attr == 'id' and self._id_linter_enabled is True:
                     raise LinterException(
                         'Use of "id" attribute in .vue files is ' +
                         'discouraged. Found one in line %d\n' % (line),
                         fixable=False)
-
 
     def handle_endtag(self, tag):
         while self._stack and self._stack[-1][0] != tag:
@@ -281,7 +280,7 @@ class VueHTMLParser(HTMLParser):
     def handle_comment(self, data):
         if data.find('id-lint ') >= 0:
             data = data.strip()
-            data_flag = data.split( )
+            data_flag = data.split(' ')
             if data_flag[1] == 'off':
                 self._id_linter_enabled = False
             elif data_flag[1] == 'on':


### PR DESCRIPTION
Se agrega linter para evitar el uso del atributo `id` en los archivos `.vue`.

En los casos que se necesite establecer un id por requerimiento, existirá una opción para deshabilitar temporalmente el linter utilizando el siguiente código:
```
<!-- id-linter off -->
    <codigo id="es_requerido">
         El código se necesita por requerimiento de algún componente
    </codigo>
<!-- id-linter on -->
```

Fixes #1584 