### PR TITLE
Improve the message when the linter fixes files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 jobs:
-  php:
+  ci:
     runs-on: ubuntu-latest
 
     steps:

--- a/git_tools.py
+++ b/git_tools.py
@@ -336,7 +336,8 @@ def _is_single_commit_pushed(args: argparse.Namespace) -> bool:
 
 def attempt_automatic_fixes(scriptname: Text,
                             args: argparse.Namespace,
-                            files: Optional[Iterable[Text]] = None) -> bool:
+                            files: Optional[Iterable[Text]] = None,
+                            pre_upload: bool = False) -> bool:
     '''Attempts to automatically fix any fixable errors.'''
     if sys.stdin.closed or not sys.stdin.isatty():
         # There is no one to ask.
@@ -352,6 +353,10 @@ def attempt_automatic_fixes(scriptname: Text,
                                     'status', '--porcelain']).strip():
         # The fix failed?
         return False
+    if pre_upload:
+        continue_message = 'please run the `git push` command again.'
+    else:
+        continue_message = 'ready to upload.'
     if not prompt('Want to also commit the fixes?'):
         # Fixes succeeded, even if they are not committed yet.
         print('Files written to working directory. '
@@ -367,8 +372,9 @@ def attempt_automatic_fixes(scriptname: Text,
         else:
             commit_params.append('--all')
         subprocess.check_call(commit_params)
-        print('%sPrevious commit reused, ready to upload.%s' %
-              (COLORS.OKGREEN, COLORS.NORMAL), file=sys.stderr)
+        print('%sPrevious commit reused, %s%s' %
+              (COLORS.OKGREEN, continue_message, COLORS.NORMAL),
+              file=sys.stderr)
     else:
         commit_params = ['/usr/bin/git', 'commit',
                          '-m', 'Fixed %s lints' % scriptname]
@@ -378,8 +384,9 @@ def attempt_automatic_fixes(scriptname: Text,
         else:
             commit_params.append('--all')
         subprocess.check_call(commit_params)
-        print('%sCommitted fixes, ready to upload.%s' %
-              (COLORS.OKGREEN, COLORS.NORMAL), file=sys.stderr)
+        print('%sCommitted fixes, %s%s' %
+              (COLORS.OKGREEN, continue_message, COLORS.NORMAL),
+              file=sys.stderr)
     return True
 
 

--- a/lint.py
+++ b/lint.py
@@ -181,6 +181,10 @@ def main() -> None:
         tool_description='lints a project',
         extra_arguments=[
             git_tools.Argument(
+                '--pre-upload',
+                action='store_true',
+                help='Mark this as being run from within a pre-upload hook'),
+            git_tools.Argument(
                 '--linters', help='Comma-separated subset of linters to run'),
         ])
     if not args.files:
@@ -228,7 +232,8 @@ def main() -> None:
                   file=sys.stderr)
         elif validate_only:
             if git_tools.attempt_automatic_fixes(sys.argv[0], args,
-                                                 file_violations):
+                                                 file_violations,
+                                                 pre_upload=args.pre_upload):
                 sys.exit(1)
             print('%sLinter validation errors.%s '
                   'Please run `%s` to fix them.' % (


### PR DESCRIPTION
This change makes the linter explicitly mention the need to re-run `git
push` when it makes changes.