### PR TITLE
Evict the omegaup-specific Python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,18 +30,10 @@ RUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
 # Python support.
 RUN python3 -m pip install --upgrade pip && \
     python3 -m pip install \
-        pylint==2.5.3 \
+        mypy==0.940 \
         pycodestyle==2.6.0 \
-        markupsafe==2.0.1 \
-        Jinja2==3.0.3 \
-        types-requests==2.27.8 \
-        pyparsing==2.4.7 \
-        mypy==0.931 \
-        pytest==6.2.5 \
-        pytest-mock==3.6.1 \
-        pika-stubs==0.1.3 \
-        pytest-stub==1.1.0 \
-        omegaup==1.5.4 && \
+        pylint==2.5.3 \
+        && \
     mkdir -p /.pylint.d && chown 1000:1000 /.pylint.d
 
 # JavaScript support.
@@ -79,4 +71,4 @@ ADD ./ /hook_tools
 RUN (cd /hook_tools && composer install)
 
 USER ubuntu
-ENTRYPOINT ["/usr/bin/python3", "/hook_tools/lint.py"]
+ENTRYPOINT ["python3", "/hook_tools/lint.py"]

--- a/git_tools.py
+++ b/git_tools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 '''
 Utility functions used to write git hooks.

--- a/git_tools_test.py
+++ b/git_tools_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """Unit tests for git_tools."""
 

--- a/lint.py
+++ b/lint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Main entrypoint for the omegaUp linting tool."""

--- a/linters_test.py
+++ b/linters_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Unit tests for the Linters."""

--- a/test/uppercase_linter.py
+++ b/test/uppercase_linter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """Trivial linter that converts to uppercase."""
 


### PR DESCRIPTION
Currently we need to make a change to this package every single time we
add a new dependency on the omegaup repository. That's a huge drag.

This change expects there to be a virtual environment in the omegaup
repository, so that all the Python tools can be managed over there.