### PR TITLE
Fix also detecting Unicode spaces (and ZWS/ZWNJ)

### DIFF
--- a/linters_test.py
+++ b/linters_test.py
@@ -44,6 +44,12 @@ class TestLinters(unittest.TestCase):
                                  ['empty lines before a closing brace']))
 
         self.assertEqual(
+            linter.run_one('test.txt', 'hello \u200b\n'.encode('utf-8')),
+            linters.SingleResult(b'hello\n', [
+                'trailing whitespace',
+            ]))
+
+        self.assertEqual(
             linter.run_one('test.txt', b'function() {\r\n\n\n// \n\n}\n'),
             linters.SingleResult(b'function() {\n//\n}\n', [
                 'Windows-style EOF',


### PR DESCRIPTION
This change interprets files as Unicode so that it can also trim all
Unicode spaces. Also including ZWS/ZWNJ as spaces even though they are
technically punctuation.