### PR TITLE
Create the docker buildx driver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
           echo "${{ secrets.DOCKER_PASSWORD }}" | \
               docker login "--username=${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
+          docker buildx create --use
+
           docker buildx build \
             --push \
             --platform=linux/amd64,linux/arm64/v8 \


### PR DESCRIPTION
Turns out that we need to create it explicitly before building.