### PR TITLE
Use Docker's actions instead of hand-rolling it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,15 +21,23 @@ jobs:
           DEFAULT_BUMP: patch
           INITIAL_VERSION: 1.0.0
 
-      - name: Build docker containers
-        run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | \
-              docker login "--username=${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      # Add support for more platforms with QEMU (optional)
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-          docker buildx create --use
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-          docker buildx build \
-            --push \
-            --platform=linux/amd64,linux/arm64/v8 \
-            --tag=${{ steps.bump-version.outputs.tag }} \
-            .
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: omegaup/hook_tools:${{ steps.bump-version.outputs.tag }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
For some reason the handrolled code is not working on GitHub. Let's rely on already-built actions instead.