### PR TITLE
Avoid re-building the package in Docker in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,5 +50,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
+          build-args:
+            - VERSION=${{ steps.bump-version.outputs.tag }}
           tags: omegaup/hook_tools:${{ steps.bump-version.outputs.tag }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
The Docker build lacks the ability to grab the git version. Instead, let's install the PyPI package that we _just_ built.